### PR TITLE
FLEETCARMA platform support + PIC32 sleep mode + CAN wake-ups

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -38,11 +38,14 @@ endif
 # 	CHIPKIT
 # 	BLUEBOARD
 # 	FORDBOARD
+# 	FLEETCARMA
 ifndef PLATFORM
 PLATFORM = CHIPKIT
 endif
 
 ifeq ($(PLATFORM), CHIPKIT)
+include pic32/pic32.mk
+else ifeq ($(PLATFORM), FLEETCARMA)
 include pic32/pic32.mk
 else
 include lpc17xx/lpc17xx.mk

--- a/src/bluetooth.h
+++ b/src/bluetooth.h
@@ -22,6 +22,10 @@ void setBluetoothStatus(bool status);
 /* Public: Perform any initialization required to control Bluetooth. */
 void initializeBluetooth();
 
+/* Public: Shut down the bluetooth peripheral (save power). */
+void deinitializeBluetooth();
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/canutil.h
+++ b/src/canutil.h
@@ -243,5 +243,10 @@ CanSignalState* lookupSignalState(const char* name, CanSignal* signal,
  */
 CanSignalState* lookupSignalState(int value, CanSignal* signal,
         CanSignal* signals, int signalCount);
+		
+/* Public: 	Change the operational mode of the specified CAN module to CAN_DISABLE.
+ *			Also set state of any off-chip CAN line driver as needed for platform.
+ */
+void setCanOpModeDisable(CanBus* bus);
 
 #endif // _CANUTIL_H_

--- a/src/pic32/bluetooth.c
+++ b/src/pic32/bluetooth.c
@@ -1,9 +1,86 @@
 #include "bluetooth.h"
+#include "gpio.h"
+#include "log.h"
+
+#if defined(FLEETCARMA)
+
+	#define BLUETOOTH_SUPPORT
+	
+	#define BLUETOOTH_ENABLE_PORT				0
+	#define BLUETOOTH_ENABLE_PIN_POLARITY		1	// drive high == power on
+	#define BLUETOOTH_ENABLE_PIN				32	// PORTE BIT5 (RE5)
+	
+	#define BLUETOOTH_STATUS_PORT				0
+	#define BLUETOOTH_STATUS_PIN_POLARITY		1	// high == connected
+	#define BLUETOOTH_STATUS_PIN				58 	// PORTB BIT4 (RB4)
+	
+#endif
 
 bool bluetoothConnected() {
-    return false;
+    
+	GpioValue value;
+	bool stat;
+	
+	#if defined(BLUETOOTH_SUPPORT)
+	value = getGpioValue(BLUETOOTH_STATUS_PORT, BLUETOOTH_STATUS_PIN);
+	switch(value) {
+		case GPIO_VALUE_HIGH:
+			stat = BLUETOOTH_STATUS_PIN_POLARITY ? true : false;
+			break;
+		case GPIO_VALUE_LOW:
+			stat = BLUETOOTH_STATUS_PIN_POLARITY ? false : true;
+			break;
+		 default:
+			stat = false;
+			break;
+	}
+	#else
+	stat = false;
+	#endif
+	
+	return stat;
+	
 }
 
-void setBluetoothStatus(bool status) { }
+void setBluetoothStatus(bool enabled) {
 
-void initializeBluetooth() { }
+	GpioValue value;
+
+	#if defined(BLUETOOTH_SUPPORT)
+	value = BLUETOOTH_ENABLE_PIN_POLARITY ? enabled : !enabled;
+
+	debug("Turning Bluetooth %s", enabled ? "on" : "off");
+	setGpioValue(BLUETOOTH_ENABLE_PORT, BLUETOOTH_ENABLE_PIN, value);
+	#endif
+	
+}
+
+void initializeBluetooth() {
+	
+	#if defined(BLUETOOTH_SUPPORT)
+	debug("Initializing Bluetooth...");
+	
+	// initialize bluetooth enable and status pins
+	setGpioDirection(BLUETOOTH_ENABLE_PORT, BLUETOOTH_ENABLE_PIN, GPIO_DIRECTION_OUTPUT);
+	setGpioDirection(BLUETOOTH_STATUS_PORT, BLUETOOTH_STATUS_PIN, GPIO_DIRECTION_INPUT);
+	
+	// enable bluetooth board
+	setBluetoothStatus(true);
+	
+	debug("Done.");
+	#endif
+	
+	return;
+
+}
+
+void deinitializeBluetooth() {
+	
+	#if defined(BLUETOOTH_SUPPORT)
+	// disable bluetooth board
+	setBluetoothStatus(false);
+	#endif
+	
+	return;
+
+}

--- a/src/pic32/canread.cpp
+++ b/src/pic32/canread.cpp
@@ -2,6 +2,7 @@
 #include "canutil_pic32.h"
 #include "signals.h"
 #include "log.h"
+#include "power.h"
 
 CanMessage receiveCanMessage(CanBus* bus) {
     CAN::RxMessageBuffer* message = CAN_CONTROLLER(bus)->getRxMessage(
@@ -22,6 +23,15 @@ CanMessage receiveCanMessage(CanBus* bus) {
 }
 
 void handleCanInterrupt(CanBus* bus) {
+
+	// handle the bus activity wake from sleep event
+	if((CAN_CONTROLLER(bus)->getModuleEvent() & CAN::BUS_ACTIVITY_WAKEUP_EVENT) != 0
+            && CAN_CONTROLLER(bus)->getPendingEventCode()
+            == CAN::WAKEUP_EVENT) {
+				handleWake();
+			}
+
+	// handle the receive message event
     if((CAN_CONTROLLER(bus)->getModuleEvent() & CAN::RX_EVENT) != 0
             && CAN_CONTROLLER(bus)->getPendingEventCode()
             == CAN::CHANNEL1_EVENT) {

--- a/src/pic32/lights.cpp
+++ b/src/pic32/lights.cpp
@@ -1,23 +1,59 @@
 #include "lights.h"
 #include "gpio.h"
 
-#define USER_LED_PIN 13
+#if defined(FLEETCARMA)
+
+	#define USER_LED_A_SUPPORT
+	#define USER_LED_A_POLARITY	0		// turn on LED = drive pin low
+	#define USER_LED_A_PIN		3		// PORTD BIT0 (RD0) = GREEN
+	
+	#define USER_LED_B_SUPPORT
+	#define USER_LED_B_POLARITY	0		// turn on LED = drive pin low
+	#define USER_LED_B_PIN		4		// PORTC BIT14 (RC14) = BLUE
+	
+#elif defined(CHIPKIT)
+	#define USER_LED_A_SUPPORT
+	#define USER_LED_A_POLARITY	1		// turn on LED = drive pin high
+	#define USER_LED_A_PIN 		13
+#endif
 
 void enable(Light light, RGB color) {
     GpioValue value;
-    if(color.r == 0 && color.g == 0 && color.b == 0) {
-        value = GPIO_VALUE_LOW;
-    } else {
-        value = GPIO_VALUE_HIGH;
-    }
+    
 
     switch(light) {
+		#if defined(USER_LED_A_SUPPORT)
         case LIGHT_A:
-            setGpioValue(0, USER_LED_PIN, value);
+			if(color.r == 0 && color.g == 0 && color.b == 0) {
+				value = USER_LED_A_POLARITY ? GPIO_VALUE_LOW : GPIO_VALUE_HIGH;
+			} else {
+				value = USER_LED_A_POLARITY ? GPIO_VALUE_HIGH : GPIO_VALUE_LOW;
+			}
+            setGpioValue(0, USER_LED_A_PIN, value);
             break;
+		#endif
+		
+		#if defined(USER_LED_B_SUPPORT)
+		case LIGHT_B:
+			if(color.r == 0 && color.g == 0 && color.b == 0) {
+				value = USER_LED_B_POLARITY ? GPIO_VALUE_LOW : GPIO_VALUE_HIGH;
+			} else {
+				value = USER_LED_B_POLARITY ? GPIO_VALUE_HIGH : GPIO_VALUE_LOW;
+			}
+            setGpioValue(0, USER_LED_B_PIN, value);
+            break;
+			#endif
+		default:
+			break;
     }
 }
 
 void initializeLights() {
-    setGpioDirection(0, USER_LED_PIN, GPIO_DIRECTION_OUTPUT);
+	#if defined(USER_LED_A_SUPPORT)
+    setGpioDirection(0, USER_LED_A_PIN, GPIO_DIRECTION_OUTPUT);
+	#endif
+	
+	#if defined(USER_LED_B_SUPPORT)
+	setGpioDirection(0, USER_LED_B_PIN, GPIO_DIRECTION_OUTPUT);
+	#endif
 }

--- a/src/pic32/pic32.mk
+++ b/src/pic32/pic32.mk
@@ -69,7 +69,7 @@ ifndef SERIAL_PORT
 	endif
 endif
 
-EXTRA_CPPFLAGS += -G0 -D__PIC32__ $(CC_SYMBOLS)
+EXTRA_CPPFLAGS += -G0 -D__PIC32__ -D$(PLATFORM) $(CC_SYMBOLS)
 
 CHIPKIT_LIBRARY_AGREEMENT_URL = http://www.digilentinc.com/Agreement.cfm?DocID=DSD-0000318
 

--- a/src/pic32/power.c
+++ b/src/pic32/power.c
@@ -1,4 +1,5 @@
 #include "power.h"
+#include "log.h"
 
 void initializePower() {
 }
@@ -7,4 +8,43 @@ void updatePower() {
 }
 
 void enterLowPowerMode() {
+	
+	/*	This function will invoke the 
+	 *	CPU power save sleep mode.
+	 *
+	 *	Bus traffic will wake the CPU and cause
+	 * 	execution to vector to the CAN module's ISR.
+	 *	The ISR will detect the event as a wakeup and call
+	 *	the wake-up handler, which simply performs a software reset.
+	 *	
+	 *	TODO: This function could be a centralized location for
+	 * 	putting peripherals in low power or OFF states. Right now that is 
+	 *  done by the caller (cantranslator.cpp).	 
+	 *	This is easy to do via direct manipulation of the peripheral control 
+	 *	registers (SFRs), but skips over the peripheral libraries.
+	 *	Using the existing C++ libraries here isn't always possible, however,
+	 *  since they can use overloaded functions, which gcc won't allow.
+	 */
+
+	debug("Going to low power mode");
+	  
+	// invoke CPU power save sleep mode
+	PowerSaveSleep();
+	  
+	/* The only peripheral configured with wake-up events should be the
+	 * CAN1 module. That event will trigger the CAN1 ISR, which will lead
+	 * directly to a software reset. Code execution should therefore never
+	 * reach this point. Nevertheless, a software reset would be prudent here.
+	 */
+	   
+	SoftReset();
+	   
+	return;
+
+}
+
+void handleWake() {
+
+	SoftReset();
+
 }

--- a/src/pic32/usbutil.cpp
+++ b/src/pic32/usbutil.cpp
@@ -127,6 +127,21 @@ void initializeUsb(UsbDevice* usbDevice) {
     debug("Done.");
 }
 
+void deinitializeUsb(UsbDevice* usbDevice) {
+
+	// disable USB (notifies stack we are disabling)
+	USBModuleDisable();
+	
+	// power off the USB peripheral
+	// TODO could not find a ready-made function or macro
+	// in the USB library to actually turn off the module.
+	// USBModuleDisable() is close to what we want, but it
+	// sets the ON bit to 1 for some reason.
+	// so, easy solution is just go right to the control register, for now
+	U1PWRCCLR = (1 << 0);
+
+}
+
 
 /* Private: Arm the given endpoint for a read from the device to host.
  *

--- a/src/power.h
+++ b/src/power.h
@@ -11,6 +11,8 @@ void updatePower();
 
 void enterLowPowerMode();
 
+void handleWake();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/usbutil.h
+++ b/src/usbutil.h
@@ -90,6 +90,11 @@ void processUsbSendQueue(UsbDevice* device);
  */
 void sendControlMessage(uint8_t* data, uint8_t length);
 
+/* Public: Disconnect from host and turn off the USB peripheral 
+ * 		  (minimal power draw). 
+ */
+void deinitializeUsb(UsbDevice*);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Added support for FLEETCARMA platform, including bluetooth power and
data and LED_A (green) and LED_B (blue).

Also added sleep mode for PIC32 micros. Also added CAN bus activity wake
up events and handling for this event that resets the device.
