### PR TITLE
Fixes encoder bug with overloaded call to buildMessage

### DIFF
--- a/src/can/canwrite.cpp
+++ b/src/can/canwrite.cpp
@@ -9,7 +9,7 @@ using openxc::util::log::debug;
 
 QUEUE_DEFINE(CanMessage);
 
-void openxc::can::write::buildMessage(const CanSignal* signal, int value,
+void openxc::can::write::buildMessage(const CanSignal* signal, uint64_t value,
         uint8_t data[], size_t length) {
     bitfield_encode_float(value, signal->bitPosition, signal->bitSize,
             signal->factor, signal->offset, data, length);

--- a/src/can/canwrite.h
+++ b/src/can/canwrite.h
@@ -86,7 +86,7 @@ uint64_t encodeNumber(const CanSignal* signal, float value, bool* send);
  * destination - The destination buffer.
  * length - The length of the destination buffer.
  */
-void buildMessage(const CanSignal* signal, int encodedValue,
+void buildMessage(const CanSignal* signal, uint64_t encodedValue,
                 uint8_t destination[], size_t length);
 
 /* Public: Write a CAN signal with the given value to the bus.


### PR DESCRIPTION
Encoded value is changed from 32-bit to 64-bit in buildMessage.