### PR TITLE
Update fabric, ecdsa versions. Force pyparsing to 2.2.0

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -13,6 +13,7 @@
   and the command line. The response will mimic the request's bus, message ID, mode, and PID (if sent).
   The response will also include a randomly generated value between 0 and 100.
   Recurring diagnostic messages when running emulator firmware are currently not supported.
+* Updated fabric, ecsda versions and force pyparsing=2.2.0 for PIP versions. (https://github.com/openxc/vi-firmware/issues/382).
 
 ## v7.2.0
 

--- a/script/bootstrap/pip-requirements.txt
+++ b/script/bootstrap/pip-requirements.txt
@@ -1,3 +1,4 @@
-Fabric==1.9.0
-ecdsa==0.11
+Fabric==1.13.1
+ecdsa==0.13
 prettyprint==0.1.5
+pyparsing==2.2.0


### PR DESCRIPTION
Fixes #382. 