### PR TITLE
Add Emulator Diagnostic Tests

### DIFF
--- a/src/diagnostics.h
+++ b/src/diagnostics.h
@@ -331,6 +331,9 @@ void receiveCanMessage(DiagnosticsManager* manager, CanBus* bus,
  */
 void sendRequests(DiagnosticsManager* manager, CanBus* bus);
 
+openxc_VehicleMessage createEmulatorDiagnosticResponse( openxc_DiagnosticRequest* commandRequest,
+        CanBus* bus, bool success);
+
 /* Public: Handle an incoming command that claims to be a diagnostic request.
  *
  * This handles requests in the OpenXC message format


### PR DESCRIPTION
### Changes
- Extracted emulator diagnostic response code into separate method for tests
- Added `test_emulator_diagnostic_response_returns_true`
    - Checks for `success = true`
    - Checks that `value` is between 0 and 100
- Added `test_emulator_diagnostic_response_returns_false`
    - Checks for `success = false`
    - Checks that `negative_response_code` is between 1 and 15
- Added `test_emulator_diagnostic_response_outside_range`
    - Checks to ensure no diagnostic response was created