### PR TITLE
Further Improve Emulator Responses

### DIFF
--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -690,15 +690,15 @@ int openxc::diagnostics::getEmulatedMessageID(int requestID)
 
 bool openxc::diagnostics::isSupportedMode(int requestMode)
 {
-    // Supported Modes (1 & 9)
-    if (requestMode == 0x1 || requestMode == 0x9)
+    // Supported Modes
+    if (requestMode == 0x1 || requestMode == 0x9 || requestMode == 0x22)
     {
         return true;
     }
     else
     {
-        // ID Outside Valid Range (701 - 7F1)
-        debug("Request mode is not supported by the emulator! Supported: 0x1, 0x9");
+        // Unsupported Modes
+        debug("Request mode is not supported by the emulator! Supported: 0x1, 0x9, 0x22");
         return false;
     }
 }
@@ -725,6 +725,16 @@ bool openxc::diagnostics::isSupportedPID(int requestMode, int requestPID)
             else
             {
                 debug("Mode 0x2 does not support that PID! Range: 0x0 - 0xB");
+            }
+            break;
+        case 0x22:
+            if (requestPID >= 0xDE00 && requestPID <= 0xDEEF)
+            {
+                return true;
+            }
+            else
+            {
+                debug("Mode 0x22 does not support that PID! Range: 0xDE00 - 0xDEEF");
             }
             break;
         default:

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -649,79 +649,152 @@ static bool handleAuthorizedCommand(DiagnosticsManager* manager,
     return status;
 }
 
-openxc_VehicleMessage openxc::diagnostics::createEmulatorDiagnosticResponse(
-        openxc_DiagnosticRequest* commandRequest, CanBus* bus, bool success)
+bool openxc::diagnostics::isSupportedMessageID(int requestID)
 {
-    openxc_VehicleMessage message = openxc_VehicleMessage();	// Zero fill
-
-    //Checking to see if the message ID is in the "standard" OBD range (7DF or 7E0->7E7)
-    //See: https://en.wikipedia.org/wiki/OBD-II_PIDs#CAN_.2811-bit.29_bus_format
-    if(commandRequest->message_id >= 0x7DF && commandRequest->message_id <= 0x7E7)
+    // ID Within Valid Range (701 - 7F1)
+    if (requestID >= 0x701 && requestID <= 0x7F1)
     {
-        message.type = openxc_VehicleMessage_Type_DIAGNOSTIC;
-        message.diagnostic_response = {0};
-        message.diagnostic_response.bus = bus->address;
-        //message.diagnostic_response.has_message_id = true;
-        //7DF should respond with a random message id between 7e8 and 7ef
-        //7E0 through 7E7 should respond with a id that is 8 higher (7E0->7E8)
-        if(commandRequest->message_id == 0x7DF)
+        // Reserved IDs
+        if (requestID != 0x703 && requestID != 0x750 && requestID != 0x7B0 && requestID != 0x7D7 && requestID != 0x7F0)
         {
-            message.diagnostic_response.message_id = rand()%(0x7EF-0x7E8 + 1) + 0x7E8;
-        }
-        else if(commandRequest->message_id >= 0x7E0 && commandRequest->message_id <= 0x7E7)
-        {
-            message.diagnostic_response.message_id = commandRequest->message_id + 8;
-        }
-        message.diagnostic_response.mode = commandRequest->mode;
-        message.diagnostic_response.pid = commandRequest->pid;
-
-        message.diagnostic_response.success = success;
-        if (message.diagnostic_response.success)
-        {
-            openxc_DynamicField value = openxc_DynamicField();	// Zero fill
-            value.type = openxc_DynamicField_Type_NUM;
-            value.numeric_value = rand() % 100;
-            message.diagnostic_response.value = value;
+            return true;
         }
         else
         {
-            message.diagnostic_response.negative_response_code = rand() % 15 + 1;
+            // Request ID = Reserved
+            debug("Request ID is reserved and not supported by the emulator! Reserved: 0x703, 0x750, 0x7B0, 0x7D7, 0x7F0");
+            return false;
         }
-
-        debug("Response message id: %d", message.diagnostic_response.message_id);
     }
-    else //If it's outside the range, the command_request will return false
+    else
     {
-        debug("Sent message ID is outside the valid range for emulator (7DF to 7E7)");
+        // ID Outside Valid Range (701 - 7F1)
+        debug("Request ID is outside the supported range by the emulator! Range: 0x701 - 0x7F1");
+        return false;
     }
-
-    return message;
 }
 
-bool openxc::diagnostics::handleDiagnosticCommand(
-        DiagnosticsManager* manager, openxc_ControlCommand* command) {
-    bool status = true;
-        openxc_DiagnosticRequest* commandRequest =
-                &command->diagnostic_request.request;
-        if((commandRequest->message_id != 0) && (commandRequest->mode != 0)) {
-            CanBus* bus = NULL;
-            if(commandRequest->bus >= 0) {
-                bus = lookupBus(commandRequest->bus, getCanBuses(),
-                        getCanBusCount());
-            } 
-	    if((bus == NULL) && (commandRequest->bus == 0) && (getCanBusCount() > 0)) {	// Could not find a bus of 0 so use the 1st one if one not asked for
-                bus = &getCanBuses()[0];
-                debug("No bus specified for diagnostic request, "
-                        "using first active: %d", bus->address);
-            }
+int openxc::diagnostics::getEmulatedMessageID(int requestID)
+{
+    if(requestID == 0x7DF)
+    {
+        // 7E8 <= Response ID <= 7EF
+        return rand() % (0x7EF - 0x7E8 + 0x1) + 0x7E8;
+    }
+    else
+    {
+        // Response ID = Request ID + 8
+        return requestID + 0x8;
+    }
+}
 
-            if(getConfiguration()->emulatedData){
-                bool success = rand() & 1;
-                openxc_VehicleMessage message = createEmulatorDiagnosticResponse(commandRequest, bus, success);
-                
-                if (message.type == openxc_VehicleMessage_Type_DIAGNOSTIC)
+bool openxc::diagnostics::isSupportedMode(int requestMode)
+{
+    // Supported Modes (1 & 9)
+    if (requestMode == 0x1 || requestMode == 0x9)
+    {
+        return true;
+    }
+    else
+    {
+        // ID Outside Valid Range (701 - 7F1)
+        debug("Request mode is not supported by the emulator! Supported: 0x1, 0x9");
+        return false;
+    }
+}
+
+bool openxc::diagnostics::isSupportedPID(int requestMode, int requestPID)
+{
+    switch (requestMode)
+    {
+        case 0x1:
+            if (requestPID >= 0x0 && requestPID <= 0xA6)
+            {
+                return true;
+            }
+            else
+            {
+                debug("Mode 0x1 does not support that PID! Range: 0x0 - 0xA6");
+            }
+            break;
+        case 0x9:
+            if (requestPID >= 0x0 && requestPID <= 0xB)
+            {
+                return true;
+            }
+            else
+            {
+                debug("Mode 0x2 does not support that PID! Range: 0x0 - 0xB");
+            }
+            break;
+        default:
+            break;
+    }
+    return false;
+}
+
+void openxc::diagnostics::generateEmulatorPayload(openxc_VehicleMessage* vehicleMessage, bool isSuccess)
+{
+    vehicleMessage->diagnostic_response.success = isSuccess;
+    if (isSuccess)
+    {
+        openxc_DynamicField value = openxc_DynamicField();
+        value.type = openxc_DynamicField_Type_NUM;
+        value.numeric_value = rand() % 0x1000;
+        vehicleMessage->diagnostic_response.value = value;
+    }
+    else
+    {
+        vehicleMessage->diagnostic_response.negative_response_code = rand() % (0xF1 - 0x10 + 0x1) + 0x10;
+    }
+}
+
+bool openxc::diagnostics::handleDiagnosticCommand(DiagnosticsManager* manager, openxc_ControlCommand* command)
+{
+    bool status = true;
+    openxc_DiagnosticRequest* commandRequest = &command->diagnostic_request.request;
+
+    if((commandRequest->message_id != 0) && (commandRequest->mode != 0))
+    {
+        CanBus* bus = NULL;
+        if(commandRequest->bus >= 0)
+        {
+            bus = lookupBus(commandRequest->bus, getCanBuses(), getCanBusCount());
+        } 
+	    if((bus == NULL) && (commandRequest->bus == 0) && (getCanBusCount() > 0))
+        {
+            // Could not find a bus of 0 so use the 1st one if one not asked for
+            bus = &getCanBuses()[0];
+            debug("No bus specified for diagnostic request, using first active: %d", bus->address);
+        }
+
+        if(getConfiguration()->emulatedData)
+        {
+            openxc_VehicleMessage message = openxc_VehicleMessage();
+            message.type = openxc_VehicleMessage_Type_DIAGNOSTIC;
+            message.diagnostic_response = { 0 };
+            message.diagnostic_response.bus = bus->address;
+
+            if (isSupportedMessageID(commandRequest->message_id))
+            {
+                message.diagnostic_response.message_id = getEmulatedMessageID(commandRequest->message_id);
+
+                if (isSupportedMode(commandRequest->mode))
                 {
-                    pipeline::publish(&message, &getConfiguration()->pipeline);
+                    message.diagnostic_response.mode = commandRequest->mode;
+
+                    if (isSupportedPID(commandRequest->mode, commandRequest->pid))
+                    {
+                        message.diagnostic_response.pid = commandRequest->pid;
+
+                        generateEmulatorPayload(&message, rand() & 1);
+
+                        pipeline::publish(&message, &getConfiguration()->pipeline);
+                    }
+                    else
+                    {
+                        status = false;
+                    }
                 }
                 else
                 {
@@ -730,21 +803,33 @@ bool openxc::diagnostics::handleDiagnosticCommand(
             }
             else
             {
-                if(bus == NULL) {
-                    debug("No active bus to send diagnostic request");
-                    status = false;
-                } else if(bus->rawWritable) {
-                        status = handleAuthorizedCommand(manager, bus, command);
-                } else {
-                    debug("Raw CAN writes not allowed for bus %d", bus->address);
-                    status = false;
-                }
+                status = false;
             }
-
-        } else {
-            debug("Diagnostic requests need at least an arb. ID and mode");
-            status = false;
         }
+        else
+        {
+            if (bus == NULL)
+            {
+                debug("No active bus to send diagnostic request");
+                status = false;
+            }
+            else if (bus->rawWritable)
+            {
+                status = handleAuthorizedCommand(manager, bus, command);
+            }
+            else
+            {
+                debug("Raw CAN writes not allowed for bus %d", bus->address);
+                status = false;
+            }
+        }
+
+    }
+    else
+    {
+        debug("Diagnostic requests need at least an arb. ID and mode");
+        status = false;
+    }
     return status;
 }
 

--- a/src/diagnostics.h
+++ b/src/diagnostics.h
@@ -331,8 +331,15 @@ void receiveCanMessage(DiagnosticsManager* manager, CanBus* bus,
  */
 void sendRequests(DiagnosticsManager* manager, CanBus* bus);
 
-openxc_VehicleMessage createEmulatorDiagnosticResponse( openxc_DiagnosticRequest* commandRequest,
-        CanBus* bus, bool success);
+bool isSupportedMessageID(int requestID);
+
+int getEmulatedMessageID(int requestID);
+
+bool isSupportedMode(int requestMode);
+
+bool isSupportedPID(int requestMode, int requestPID);
+
+void generateEmulatorPayload(openxc_VehicleMessage* vehicleMessage, bool isSuccess);
 
 /* Public: Handle an incoming command that claims to be a diagnostic request.
  *

--- a/src/tests/diagnostics_tests.cpp
+++ b/src/tests/diagnostics_tests.cpp
@@ -977,13 +977,15 @@ START_TEST(test_emulator_modes_supported)
 {
     ck_assert(diagnostics::isSupportedMode(0x1) == true);
     ck_assert(diagnostics::isSupportedMode(0x9) == true);
+    ck_assert(diagnostics::isSupportedMode(0x22) == true);
 }
 END_TEST
 
 START_TEST(test_emulator_modes_not_supported)
 {
     ck_assert(diagnostics::isSupportedMode(0x2) == false);
-    ck_assert(diagnostics::isSupportedMode(0x22) == false);
+    ck_assert(diagnostics::isSupportedMode(0x7) == false);
+    ck_assert(diagnostics::isSupportedMode(0x23) == false);
 }
 END_TEST
 
@@ -991,6 +993,7 @@ START_TEST(test_emulator_pids_supported)
 {
     ck_assert(diagnostics::isSupportedPID(0x1, 0xA0) == true);
     ck_assert(diagnostics::isSupportedPID(0x9, 0xA) == true);
+    ck_assert(diagnostics::isSupportedPID(0x22, 0xDE05) == true);
 }
 END_TEST
 
@@ -998,6 +1001,7 @@ START_TEST(test_emulator_pids_not_supported)
 {
     ck_assert(diagnostics::isSupportedPID(0x1, 0xA7) == false);
     ck_assert(diagnostics::isSupportedPID(0x9, 0xC) == false);
+    ck_assert(diagnostics::isSupportedPID(0x22, 0xDEF0) == false);
     ck_assert(diagnostics::isSupportedPID(0x2, 0x0) == false);
 }
 END_TEST

--- a/src/tests/diagnostics_tests.cpp
+++ b/src/tests/diagnostics_tests.cpp
@@ -937,43 +937,90 @@ START_TEST(test_can_filters_disabled)
 }
 END_TEST
 
-START_TEST(test_emulator_diagnostic_response_returns_true)
+START_TEST(test_emulator_message_ids_supported_range)
 {
-    openxc_DiagnosticRequest commandRequest = openxc_DiagnosticRequest();
-    commandRequest.message_id = 0x7DF;
-    commandRequest.mode = 0x1;
-    commandRequest.pid = 0x5;
-    openxc_VehicleMessage message = diagnostics::createEmulatorDiagnosticResponse(&commandRequest, &getCanBuses()[0], true);
-
-    ck_assert(message.diagnostic_response.success);
-    ck_assert_int_ge(message.diagnostic_response.value.numeric_value, 0);
-    ck_assert_int_le(message.diagnostic_response.value.numeric_value, 100);
+    ck_assert(diagnostics::isSupportedMessageID(0x701) == true);
+    ck_assert(diagnostics::isSupportedMessageID(0x7DF) == true);
+    ck_assert(diagnostics::isSupportedMessageID(0x7F1) == true);
 }
 END_TEST
 
-START_TEST(test_emulator_diagnostic_response_returns_false)
+START_TEST(test_emulator_message_ids_not_supported_range)
 {
-    openxc_DiagnosticRequest commandRequest = openxc_DiagnosticRequest();
-    commandRequest.message_id = 0x7DF;
-    commandRequest.mode = 0x1;
-    commandRequest.pid = 0x5;
-    openxc_VehicleMessage message = diagnostics::createEmulatorDiagnosticResponse(&commandRequest, &getCanBuses()[0], false);
-
-    ck_assert(!message.diagnostic_response.success);
-    ck_assert_int_ge(message.diagnostic_response.negative_response_code, 1);
-    ck_assert_int_le(message.diagnostic_response.negative_response_code, 15);
+    ck_assert(diagnostics::isSupportedMessageID(0x700) == false);
+    ck_assert(diagnostics::isSupportedMessageID(0x7F2) == false);
 }
 END_TEST
 
-START_TEST(test_emulator_diagnostic_response_outside_range)
+START_TEST(test_emulator_message_ids_not_supported_reserved)
 {
-    openxc_DiagnosticRequest commandRequest = openxc_DiagnosticRequest();
-    commandRequest.message_id = 0x7F0;
-    commandRequest.mode = 0x1;
-    commandRequest.pid = 0x5;
-    openxc_VehicleMessage message = diagnostics::createEmulatorDiagnosticResponse(&commandRequest, &getCanBuses()[0], true);
+    ck_assert(diagnostics::isSupportedMessageID(0x703) == false);
+    ck_assert(diagnostics::isSupportedMessageID(0x750) == false);
+    ck_assert(diagnostics::isSupportedMessageID(0x7B0) == false);
+    ck_assert(diagnostics::isSupportedMessageID(0x7D7) == false);
+    ck_assert(diagnostics::isSupportedMessageID(0x7F0) == false);
+}
+END_TEST
 
-    ck_assert(message.type != openxc_VehicleMessage_Type_DIAGNOSTIC);
+START_TEST(test_emulator_response_message_id)
+{
+    int responseMessageID = diagnostics::getEmulatedMessageID(0x7DF);
+    ck_assert_int_ge(responseMessageID, 0x7E8);
+    ck_assert_int_le(responseMessageID, 0x7EF);
+
+    responseMessageID = diagnostics::getEmulatedMessageID(0x7E0);
+    ck_assert_int_eq(responseMessageID, 0x7E0 + 0x8);
+}
+END_TEST
+
+START_TEST(test_emulator_modes_supported)
+{
+    ck_assert(diagnostics::isSupportedMode(0x1) == true);
+    ck_assert(diagnostics::isSupportedMode(0x9) == true);
+}
+END_TEST
+
+START_TEST(test_emulator_modes_not_supported)
+{
+    ck_assert(diagnostics::isSupportedMode(0x2) == false);
+    ck_assert(diagnostics::isSupportedMode(0x22) == false);
+}
+END_TEST
+
+START_TEST(test_emulator_pids_supported)
+{
+    ck_assert(diagnostics::isSupportedPID(0x1, 0xA0) == true);
+    ck_assert(diagnostics::isSupportedPID(0x9, 0xA) == true);
+}
+END_TEST
+
+START_TEST(test_emulator_pids_not_supported)
+{
+    ck_assert(diagnostics::isSupportedPID(0x1, 0xA7) == false);
+    ck_assert(diagnostics::isSupportedPID(0x9, 0xC) == false);
+    ck_assert(diagnostics::isSupportedPID(0x2, 0x0) == false);
+}
+END_TEST
+
+START_TEST(test_emulator_returns_successful)
+{
+    openxc_VehicleMessage message = openxc_VehicleMessage();
+    diagnostics::generateEmulatorPayload(&message, true);
+
+    ck_assert(message.diagnostic_response.success == true);
+    ck_assert_int_ge(message.diagnostic_response.value.numeric_value, 0x0);
+    ck_assert_int_le(message.diagnostic_response.value.numeric_value, 0x1000);
+}
+END_TEST
+
+START_TEST(test_emulator_returns_not_successful)
+{
+    openxc_VehicleMessage message = openxc_VehicleMessage();
+    diagnostics::generateEmulatorPayload(&message, false);
+
+    ck_assert(message.diagnostic_response.success == false);
+    ck_assert_int_ge(message.diagnostic_response.negative_response_code, 0x10);
+    ck_assert_int_le(message.diagnostic_response.negative_response_code, 0xF1);
 }
 END_TEST
 
@@ -1034,9 +1081,16 @@ Suite* suite(void) {
 
     tcase_add_test(tc_core, test_ignition_check_power_management_uses_watchdog);
 
-    tcase_add_test(tc_core, test_emulator_diagnostic_response_returns_true);
-    tcase_add_test(tc_core, test_emulator_diagnostic_response_returns_false);
-    tcase_add_test(tc_core, test_emulator_diagnostic_response_outside_range);
+    tcase_add_test(tc_core, test_emulator_message_ids_supported_range);
+    tcase_add_test(tc_core, test_emulator_message_ids_not_supported_range);
+    tcase_add_test(tc_core, test_emulator_message_ids_not_supported_reserved);
+    tcase_add_test(tc_core, test_emulator_response_message_id);
+    tcase_add_test(tc_core, test_emulator_modes_supported);
+    tcase_add_test(tc_core, test_emulator_modes_not_supported);
+    tcase_add_test(tc_core, test_emulator_pids_supported);
+    tcase_add_test(tc_core, test_emulator_pids_not_supported);
+    tcase_add_test(tc_core, test_emulator_returns_successful);
+    tcase_add_test(tc_core, test_emulator_returns_not_successful);
 
     suite_add_tcase(s, tc_core);
 


### PR DESCRIPTION
### Changes
- Extended supported message ID range
- Added reserved message IDs
- Extended NRC range
- Limited supported modes
- Limited supported PIDS based on supported mode
- Extended random value range
- Added support for specific 2 byte PIDs
- Rewrote old and added new test cases

### Emulator Supported Request Info
This is a reference for what requests are now supported by the emulator.
- **Message ID:** 0x701 - 0x7F1
    - **Reserved (Unsupported):** 0x703, 0x750, 0x7B0, 0x7D7, 0x7F0
- **Mode (PID):** 0x1 _(0x0 - 0xA6)_, 0x9 _(0x0 - 0xB)_, 0x22 _(DE00 - DEEF)_

### Emulator Response Info
This is a reference for what responses will be returned by the emulator.
- **Success:** Random
- **NRC:** Random (0x10 - 0xF1)
- **Value:** Random (0x0 - 0x1000)