### PR TITLE
Update SonarQube Properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,7 @@
 sonar.projectKey=com.ford.VI-Firmware
+
+# Uncommet the sonar.language line if you're using a local SonarQube instance
+# You will need the community C++ plugin
+# https://github.com/SonarOpenCommunity/sonar-cxx
+
+# sonar.language=c++

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,1 @@
-sonar.projectKey=VI-Firmware
+sonar.projectKey=com.ford.VI-Firmware

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,1 @@
 sonar.projectKey=VI-Firmware
-sonar.language=c++


### PR DESCRIPTION
### Changes
- Commented out the `sonar.language` property due to conflicts with the enterprise version of SonarQube