### PR TITLE
Get vin from diagnostic

### DIFF
--- a/src/commands/commands.cpp
+++ b/src/commands/commands.cpp
@@ -19,6 +19,7 @@
 #include "commands/modem_config_command.h"
 #include "commands/rtc_config_command.h"
 #include "commands/sd_mount_status_command.h"
+#include "commands/get_vin_command.h"
 
 
 using openxc::util::log::debug;
@@ -63,6 +64,8 @@ static bool handleComplexCommand(openxc_VehicleMessage* message) {
             break;
         case openxc_ControlCommand_Type_SD_MOUNT_STATUS:
             status =  openxc::commands::handleSDMountStatusCommand();
+        case openxc_ControlCommand_Type_GET_VIN:
+            status = openxc::commands::handleGetVinCommand();
         default:
             status = false;
             break;
@@ -144,6 +147,7 @@ static bool validateControlCommand(openxc_VehicleMessage* message) {
         case openxc_ControlCommand_Type_DEVICE_ID:
         case openxc_ControlCommand_Type_PLATFORM:
         case openxc_ControlCommand_Type_SD_MOUNT_STATUS:
+        case openxc_ControlCommand_Type_GET_VIN:
             valid =  true;
             break;
         case openxc_ControlCommand_Type_MODEM_CONFIGURATION:
@@ -183,6 +187,8 @@ bool openxc::commands::validate(openxc_VehicleMessage* message) {
 
 void openxc::commands::sendCommandResponse(openxc_ControlCommand_Type commandType,
         bool status, char* responseMessage, size_t responseMessageLength) {
+            debug("Command response value %d", responseMessage);
+            debug("Command response value %s", responseMessage);
     openxc_VehicleMessage message = openxc_VehicleMessage();	// Zero Fill
     message.type = openxc_VehicleMessage_Type_COMMAND_RESPONSE;
     message.command_response.type = commandType;

--- a/src/commands/commands.cpp
+++ b/src/commands/commands.cpp
@@ -187,8 +187,6 @@ bool openxc::commands::validate(openxc_VehicleMessage* message) {
 
 void openxc::commands::sendCommandResponse(openxc_ControlCommand_Type commandType,
         bool status, char* responseMessage, size_t responseMessageLength) {
-            debug("Command response value %d", responseMessage);
-            debug("Command response value %s", responseMessage);
     openxc_VehicleMessage message = openxc_VehicleMessage();	// Zero Fill
     message.type = openxc_VehicleMessage_Type_COMMAND_RESPONSE;
     message.command_response.type = commandType;

--- a/src/commands/diagnostic_request_command.cpp
+++ b/src/commands/diagnostic_request_command.cpp
@@ -33,6 +33,7 @@ namespace uart = openxc::interface::uart;
 namespace pipeline = openxc::pipeline;
 
 bool openxc::commands::handleDiagnosticRequestCommand(openxc_ControlCommand* command) {
+    openxc::diagnostics::setVinCommandInProgress(false);
     bool status = diagnostics::handleDiagnosticCommand(
             &getConfiguration()->diagnosticsManager, command);
     sendCommandResponse(openxc_ControlCommand_Type_DIAGNOSTIC, status);

--- a/src/commands/get_vin_command.cpp
+++ b/src/commands/get_vin_command.cpp
@@ -34,16 +34,14 @@ namespace uart = openxc::interface::uart;
 namespace pipeline = openxc::pipeline;
 
 bool openxc::commands::handleGetVinCommand() {
+    char* vin;
 
     if (openxc::diagnostics::haveVINfromCan()) {
-    char* vin = (char *)openxc::diagnostics::getVIN();
-    debug("Testing for Jamez line 66 getVinCommand.cpp");
-    debug(vin);
-    debug((const char*)strlen(vin));
-    sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, true, vin, strlen(vin));
-    } else if(!openxc::diagnostics::haveVINfromCan()) {
+    	vin = (char *)openxc::diagnostics::getVIN();
+        sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, true, vin, strlen(vin));
+    } else {
         openxc_ControlCommand command = openxc_ControlCommand();	// Zero Fill
-    command.type = openxc_ControlCommand_Type_DIAGNOSTIC;
+        command.type = openxc_ControlCommand_Type_DIAGNOSTIC;
 
         command.type = openxc_ControlCommand_Type_DIAGNOSTIC;
         command.diagnostic_request.action =
@@ -59,11 +57,6 @@ bool openxc::commands::handleGetVinCommand() {
             &getConfiguration()->diagnosticsManager, &command);
         diagnostics::sendRequests(&getConfiguration()->diagnosticsManager, &getCanBuses()[0]);
     }
-    else {
-        char* vin = strdup(config::getConfiguration()->dummyVin);
-        sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, true, vin, strlen(vin));
-    }
-    
 
     return true;
 }

--- a/src/commands/get_vin_command.cpp
+++ b/src/commands/get_vin_command.cpp
@@ -1,0 +1,44 @@
+#include "get_vin_command.h"
+
+#include "config.h"
+#include "diagnostics.h"
+#include "interface/usb.h"
+#include "util/log.h"
+#include "config.h"
+#include "pb_decode.h"
+#include <payload/payload.h>
+#include "signals.h"
+#include <can/canutil.h>
+#include <bitfield/bitfield.h>
+#include <limits.h>
+
+using openxc::util::log::debug;
+using openxc::config::getConfiguration;
+using openxc::payload::PayloadFormat;
+using openxc::signals::getCanBuses;
+using openxc::signals::getCanBusCount;
+using openxc::signals::getSignals;
+using openxc::signals::getSignalCount;
+using openxc::signals::getCommands;
+using openxc::signals::getCommandCount;
+using openxc::can::lookupBus;
+using openxc::can::lookupSignal;
+
+namespace can = openxc::can;
+namespace payload = openxc::payload;
+namespace config = openxc::config;
+namespace diagnostics = openxc::diagnostics;
+namespace usb = openxc::interface::usb;
+namespace uart = openxc::interface::uart;
+namespace pipeline = openxc::pipeline;
+
+bool openxc::commands::handleGetVinCommand() {
+    char* vin;
+    bool status = false;
+    if((rand() % (10-1+1)+1)<=9) {
+        status = true;
+        vin = strdup(config::getConfiguration()->dummyVin);
+        sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, status, vin, strlen(vin));
+    }   
+    return status;
+}

--- a/src/commands/get_vin_command.cpp
+++ b/src/commands/get_vin_command.cpp
@@ -34,15 +34,14 @@ namespace uart = openxc::interface::uart;
 namespace pipeline = openxc::pipeline;
 
 bool openxc::commands::handleGetVinCommand() {
-    char* vin;
-    bool status = false;
-    vin = (char*)openxc::diagnostics::getVIN();
 
-    // if (openxc::diagnostics::haveVINfromCan()) {
-    // 	status = true;
-    // 	vin = (char *)openxc::diagnostics::getVIN();
-    // } else 
-    if(status == false) {
+    if (openxc::diagnostics::haveVINfromCan()) {
+    char* vin = (char *)openxc::diagnostics::getVIN();
+    debug("Testing for Jamez line 66 getVinCommand.cpp");
+    debug(vin);
+    debug((const char*)strlen(vin));
+    sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, true, vin, strlen(vin));
+    } else if(!openxc::diagnostics::haveVINfromCan()) {
         openxc_ControlCommand command = openxc_ControlCommand();	// Zero Fill
     command.type = openxc_ControlCommand_Type_DIAGNOSTIC;
 
@@ -54,21 +53,17 @@ bool openxc::commands::handleGetVinCommand() {
         command.diagnostic_request.request.mode = 9;
         command.diagnostic_request.request.message_id = 0x7e0;
         command.diagnostic_request.request.pid = 2;
+        openxc::diagnostics::setVinCommandInProgress(true);
 
         diagnostics::handleDiagnosticCommand(
             &getConfiguration()->diagnosticsManager, &command);
-        // sendCommandResponse(openxc_ControlCommand_Type_DIAGNOSTIC, status);
-        // vin = "test";
         diagnostics::sendRequests(&getConfiguration()->diagnosticsManager, &getCanBuses()[0]);
     }
     else {
-        status = true;
-        vin = strdup(config::getConfiguration()->dummyVin);
+        char* vin = strdup(config::getConfiguration()->dummyVin);
+        sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, true, vin, strlen(vin));
     }
-    // debug("Testing for Jamez line 66 getVinCommand.cpp");
-    // debug(vin);
-    // debug((const char*)strlen(vin));
-    // sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, status, vin, strlen(vin));
+    
 
-    return status;
+    return true;
 }

--- a/src/commands/get_vin_command.cpp
+++ b/src/commands/get_vin_command.cpp
@@ -35,10 +35,15 @@ namespace pipeline = openxc::pipeline;
 bool openxc::commands::handleGetVinCommand() {
     char* vin;
     bool status = false;
-    if((rand() % (10-1+1)+1)<=9) {
+
+    if (openxc::diagnostics::haveVINfromCan()) {
+    	status = true;
+    	vin = (char *)openxc::diagnostics::getVIN();
+    } else {
         status = true;
         vin = strdup(config::getConfiguration()->dummyVin);
-        sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, status, vin, strlen(vin));
-    }   
+    }
+    sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, status, vin, strlen(vin));
+
     return status;
 }

--- a/src/commands/get_vin_command.h
+++ b/src/commands/get_vin_command.h
@@ -1,0 +1,12 @@
+#ifndef __GET_VIN_COMMAND_H__
+#define __GET_VIN_COMMAND_H__
+
+namespace openxc {
+namespace commands {
+
+bool handleGetVinCommand();
+
+} // namespace commands
+} // namespace openxc
+
+#endif // __GET_VIN_COMMAND_H__

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -119,6 +119,7 @@ openxc::config::Configuration* openxc::config::getConfiguration() {
     static openxc::config::Configuration CONFIG = {
         messageSetIndex: 0,
         version: "8.0.0",
+        dummyVin: "00000000123456789",
         platform: PLATFORM,
         environmentMode: ENVIRONMENT_MODE,
         payloadFormat: PayloadFormat::DEFAULT_OUTPUT_FORMAT,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -119,7 +119,7 @@ openxc::config::Configuration* openxc::config::getConfiguration() {
     static openxc::config::Configuration CONFIG = {
         messageSetIndex: 0,
         version: "8.0.0",
-        dummyVin: "00000000123456789",
+        dummyVin: "Failed to get VIN tempory VIN is :00000000123456789",
         platform: PLATFORM,
         environmentMode: ENVIRONMENT_MODE,
         payloadFormat: PayloadFormat::DEFAULT_OUTPUT_FORMAT,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -119,7 +119,7 @@ openxc::config::Configuration* openxc::config::getConfiguration() {
     static openxc::config::Configuration CONFIG = {
         messageSetIndex: 0,
         version: "8.0.0",
-        dummyVin: "Failed to get VIN tempory VIN is :00000000123456789",
+        dummyVin: "Failed to get VIN temporary VIN is :00000000123456789",
         platform: PLATFORM,
         environmentMode: ENVIRONMENT_MODE,
         payloadFormat: PayloadFormat::DEFAULT_OUTPUT_FORMAT,

--- a/src/config.h
+++ b/src/config.h
@@ -110,6 +110,7 @@ typedef enum {
 typedef struct {
     int messageSetIndex;
     const char* version;
+    const char* dummyVin;
     const char* platform;
     const char* environmentMode;
     openxc::payload::PayloadFormat payloadFormat;

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -537,13 +537,13 @@ void openxc::diagnostics::checkForVinCommand(CanMessage *message) {
     // Step 3: When all of the VIN data is complete return sendCommandResponse with VIN
 
         char* vin = (char *)vinBuffer;
-        if (strlen(vin)) {
+        if (strlen(vin) == VIN_LENGTH) {
             openxc::commands::sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, 1, vin, strlen(vin));
             setVinCommandInProgress(false);
     // VIN command completed 
             vinComplete = true;
         } else {
-            vin = strdup(config::getConfiguration()->dummyVin);
+            vin = config::getConfiguration()->dummyVin;
             debug("get_vin Command failed.");
             openxc::commands::sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, 1, vin, strlen(vin));
             setVinCommandInProgress(false);

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -537,7 +537,7 @@ void openxc::diagnostics::checkForVinCommand(CanMessage *message) {
     // Step 3: When all of the VIN data is complete return sendCommandResponse with VIN
 
         char* vin = (char *)vinBuffer;
-        if (vin) {
+        if (strlen(vin)) {
             openxc::commands::sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, 1, vin, strlen(vin));
             setVinCommandInProgress(false);
     // VIN command completed 

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -537,10 +537,20 @@ void openxc::diagnostics::checkForVinCommand(CanMessage *message) {
     // Step 3: When all of the VIN data is complete return sendCommandResponse with VIN
 
         char* vin = (char *)vinBuffer;
-        openxc::commands::sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, 1, vin, strlen(vin));
-        setVinCommandInProgress(false);
+        if (vin) {
+            openxc::commands::sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, 1, vin, strlen(vin));
+            setVinCommandInProgress(false);
     // VIN command completed 
-        vinComplete = true;
+            vinComplete = true;
+        } else {
+            vin = strdup(config::getConfiguration()->dummyVin);
+            debug("get_vin Command failed.");
+            openxc::commands::sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, 1, vin, strlen(vin));
+            setVinCommandInProgress(false);
+    // VIN command completed 
+            vinComplete = true;
+            
+        }
     }
 }
 

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -459,18 +459,18 @@ void openxc::diagnostics::filterForVIN(CanMessage* message) {
         (message->data[1] <= 0x02)) {
 
         // gja debug here!
-        char buffer[26];
-        buffer[0] = '>';
-        int indx=1;
-        for(int cnt=0; cnt<message->length; cnt++) {
-            int c = (message->data[cnt] & 0xf0) >> 4;
-            buffer[indx++] = (c > 9) ? (c - 10 + 'a') : c + '0';
-            c = (message->data[cnt] & 0x0f);
-            buffer[indx++] = (c > 9) ? (c - 10 + 'a') : c + '0';
-            buffer[indx++] = ' ';
-            buffer[indx] = 0;
-        }
-        debug(buffer);
+        // char buffer[26];
+        // buffer[0] = '>';
+        // int indx=1;
+        // for(int cnt=0; cnt<message->length; cnt++) {
+        //     int c = (message->data[cnt] & 0xf0) >> 4;
+        //     buffer[indx++] = (c > 9) ? (c - 10 + 'a') : c + '0';
+        //     c = (message->data[cnt] & 0x0f);
+        //     buffer[indx++] = (c > 9) ? (c - 10 + 'a') : c + '0';
+        //     buffer[indx++] = ' ';
+        //     buffer[indx] = 0;
+        // }
+        // debug(buffer);
         // gja debug above here!
 
         int index = message->data[1] * VIN_SNIPPET_LENGTH;

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -452,7 +452,7 @@ unsigned char *openxc::diagnostics::getVIN() {
     return vinBuffer;
 }
 
-void filterForVIN(CanMessage* message) {
+void openxc::diagnostics::filterForVIN(CanMessage* message) {
 
     if ((message->id == 0x40a) &&
         (message->data[0] == 0xc1) && 
@@ -590,8 +590,6 @@ static void receiveCanMessage(DiagnosticsManager* manager,
 void openxc::diagnostics::receiveCanMessage(DiagnosticsManager* manager,
         CanBus* bus, CanMessage* message, Pipeline* pipeline) {
     ActiveDiagnosticRequest* entry;
-
-    filterForVIN(message);
 
     TAILQ_FOREACH(entry, &manager->recurringRequests, queueEntries) {
         receiveCanMessage(manager, bus, entry, message, pipeline);

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -546,7 +546,8 @@ static void relayDiagnosticResponse(DiagnosticsManager* manager,
         request->callback(manager, request, response, parsed_value);
     }
 }
-
+void sendCommandResponse(openxc_ControlCommand_Type commandType,
+    bool status, char* responseMessage, size_t responseMessageLength);
 static void receiveCanMessage(DiagnosticsManager* manager,
         CanBus* bus,
         ActiveDiagnosticRequest* entry,
@@ -558,8 +559,12 @@ static void receiveCanMessage(DiagnosticsManager* manager,
                 // coupled?
                 &manager->shims[bus->address - 1],
                 &entry->handle, message->id, message->data, message->length);
-
+                debug("Raw Message for get_vin");
+                debug((const char*)message->data);
         if (response.multi_frame) {
+            // checkForVinCommand(message);
+            char* vin = (char*)"receiveCanMessage";
+            openxc::commands::sendCommandResponse(openxc_ControlCommand_Type_GET_VIN, 1, vin, strlen(vin));
 #if (MULTIFRAME != 0)
             if (originalStitchAlgo) {
                 relayPartialFrame(manager, entry, &response, pipeline);

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -444,6 +444,14 @@ const int VIN_SNIPPET_LENGTH = 6;   // 6 VIN characters per CAN msg
 unsigned char vinBuffer[VIN_STORAGE_LENGTH] = {0};
 bool vinComplete = false;
 
+bool openxc::diagnostics::haveVINfromCan() {
+    return vinComplete;
+}
+
+unsigned char *openxc::diagnostics::getVIN() {
+    return vinBuffer;
+}
+
 void filterForVIN(CanMessage* message) {
 
     if ((message->id == 0x40a) &&

--- a/src/diagnostics.h
+++ b/src/diagnostics.h
@@ -396,6 +396,7 @@ unsigned char *getDiagnosticVIN();
 void filterForVIN(CanMessage* message);
 void checkForVinCommand(CanMessage *message);
 void setVinCommandInProgress(bool vinInProgress);
+void sendGetVinError();
 
 
 } // namespace diagnostics

--- a/src/diagnostics.h
+++ b/src/diagnostics.h
@@ -394,6 +394,8 @@ unsigned char *getDiagnosticVIN();
 * Sniff the can traffic for the specific VIN CAN messages
 */
 void filterForVIN(CanMessage* message);
+void checkForVinCommand(CanMessage *message);
+void setVinCommandInProgress(bool vinInProgress);
 
 
 } // namespace diagnostics

--- a/src/diagnostics.h
+++ b/src/diagnostics.h
@@ -377,6 +377,19 @@ bool handleDiagnosticCommand(DiagnosticsManager* manager,
 void passthroughDecoder(const DiagnosticResponse* response,
         float parsed_payload, char* str_buf, int buf_size);
 
+
+/*
+* If the VIN has been scanned from the CAN bus and stored
+* this method will return true.
+*/
+bool haveVINfromCan();
+
+/*
+* Get the VIN that was scanned from the CAN
+*/
+unsigned char *getVIN();
+
+
 } // namespace diagnostics
 } // namespace openxc
 

--- a/src/diagnostics.h
+++ b/src/diagnostics.h
@@ -389,6 +389,11 @@ bool haveVINfromCan();
 */
 unsigned char *getVIN();
 
+/*
+* Sniff the can traffic for the specific VIN CAN messages
+*/
+void filterForVIN(CanMessage* message);
+
 
 } // namespace diagnostics
 } // namespace openxc

--- a/src/diagnostics.h
+++ b/src/diagnostics.h
@@ -389,6 +389,7 @@ bool haveVINfromCan();
 */
 unsigned char *getVIN();
 
+unsigned char *getDiagnosticVIN();
 /*
 * Sniff the can traffic for the specific VIN CAN messages
 */

--- a/src/payload/json.cpp
+++ b/src/payload/json.cpp
@@ -234,6 +234,12 @@ static cJSON* serializeDynamicField(openxc_DynamicField* field) {
     }
     return value;
 }
+void dumpNum(int value);
+void dumpDouble(double value) {
+    char buff[20];
+    sprintf(buff, "%f", value);
+    debug(buff);
+}
 
 static bool serializeSimple(openxc_VehicleMessage* message, cJSON* root) {
     const char* name = message->simple_message.name;
@@ -366,6 +372,8 @@ static void deserializeDiagnostic(cJSON* root, openxc_ControlCommand* command) {
 
         element = cJSON_GetObjectItem(request, "mode");
         if(element != NULL) {
+            debug("mode");
+            dumpNum(element->valueint);
             command->diagnostic_request.request.mode = element->valueint;
         }
 
@@ -389,12 +397,16 @@ static void deserializeDiagnostic(cJSON* root, openxc_ControlCommand* command) {
 
         element = cJSON_GetObjectItem(request, "multiple_responses");
         if(element != NULL) {
+        debug("multiple_responses:");
+        dumpNum(element->valueint);
             command->diagnostic_request.request.multiple_responses =
                 bool(element->valueint);
         }
 
         element = cJSON_GetObjectItem(request, "frequency");
         if(element != NULL) {
+        debug("frequency:");
+        dumpDouble(element->valuedouble);
             command->diagnostic_request.request.frequency =
                 element->valuedouble;
         }
@@ -402,9 +414,11 @@ static void deserializeDiagnostic(cJSON* root, openxc_ControlCommand* command) {
         element = cJSON_GetObjectItem(request, "decoded_type");
         if(element != NULL) {
             if(!strcmp(element->valuestring, "obd2")) {
+                debug("decoded_type is obd2");
                 command->diagnostic_request.request.decoded_type =
                         openxc_DiagnosticRequest_DecodedType_OBD2;
             } else if(!strcmp(element->valuestring, "none")) {
+                debug("decoded_type is none");
                 command->diagnostic_request.request.decoded_type =
                         openxc_DiagnosticRequest_DecodedType_NONE;
             }
@@ -412,6 +426,8 @@ static void deserializeDiagnostic(cJSON* root, openxc_ControlCommand* command) {
 
         element = cJSON_GetObjectItem(request, "name");
         if(element != NULL && element->type == cJSON_String) {
+            debug("name");
+            debug(element->valuestring);
             strcpy(command->diagnostic_request.request.name,
                     element->valuestring);
         }

--- a/src/payload/json.cpp
+++ b/src/payload/json.cpp
@@ -25,6 +25,7 @@ const char openxc::payload::json::PREDEFINED_OBD2_REQUESTS_COMMAND_NAME[] = "pre
 const char openxc::payload::json::MODEM_CONFIGURATION_COMMAND_NAME[] = "modem_configuration";
 const char openxc::payload::json::RTC_CONFIGURATION_COMMAND_NAME[] = "rtc_configuration";
 const char openxc::payload::json::SD_MOUNT_STATUS_COMMAND_NAME[] = "sd_mount_status";
+const char openxc::payload::json::GET_VIN_COMMAND_NAME[] = "get_vin";
 
 const char openxc::payload::json::PAYLOAD_FORMAT_JSON_NAME[] = "json";
 const char openxc::payload::json::PAYLOAD_FORMAT_PROTOBUF_NAME[] = "protobuf";
@@ -154,6 +155,8 @@ static bool serializeCommandResponse(openxc_VehicleMessage* message,
         typeString = payload::json::VERSION_COMMAND_NAME;
     } else if(message->command_response.type == openxc_ControlCommand_Type_DEVICE_ID) {
         typeString = payload::json::DEVICE_ID_COMMAND_NAME;
+    } else if(message->command_response.type == openxc_ControlCommand_Type_GET_VIN) {
+        typeString = payload::json::GET_VIN_COMMAND_NAME;
     } else if(message->command_response.type == openxc_ControlCommand_Type_PLATFORM) {
         typeString = payload::json::DEVICE_PLATFORM_COMMAND_NAME;
     } else if(message->command_response.type == openxc_ControlCommand_Type_DIAGNOSTIC) {
@@ -565,6 +568,10 @@ size_t openxc::payload::json::deserialize(uint8_t payload[], size_t length,
                         DEVICE_ID_COMMAND_NAME, strlen(DEVICE_ID_COMMAND_NAME))) {
                 command->type = openxc_ControlCommand_Type_DEVICE_ID;
             } else if(!strncmp(commandNameObject->valuestring,
+                        GET_VIN_COMMAND_NAME, strlen(GET_VIN_COMMAND_NAME))) {
+                command->type = openxc_ControlCommand_Type_GET_VIN;
+                        }
+             else if(!strncmp(commandNameObject->valuestring,
                         DEVICE_PLATFORM_COMMAND_NAME, strlen(DEVICE_PLATFORM_COMMAND_NAME))) {
                 command->type = openxc_ControlCommand_Type_PLATFORM;
             } else if(!strncmp(commandNameObject->valuestring,

--- a/src/payload/json.h
+++ b/src/payload/json.h
@@ -12,6 +12,7 @@ namespace json {
 extern const char VERSION_COMMAND_NAME[];
 extern const char DEVICE_ID_COMMAND_NAME[];
 extern const char DEVICE_PLATFORM_COMMAND_NAME[];
+extern const char GET_VIN_COMMAND_NAME[];
 extern const char DIAGNOSTIC_COMMAND_NAME[];
 extern const char PASSTHROUGH_COMMAND_NAME[];
 extern const char ACCEPTANCE_FILTER_BYPASS_COMMAND_NAME[];

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -80,6 +80,8 @@ void sendToUsb(Pipeline* pipeline, uint8_t* message, int messageSize,
         }
 
         conditionalFlush(pipeline, sendQueue, message, messageSize);
+        debug("sendtoUSB debug pipeline line 83");
+        debug((const char*)message);
         sendToEndpoint(pipeline->usb->descriptor.type, sendQueue,
                 &pipeline->usb->endpoints[OUT_ENDPOINT_INDEX].queue,
                 message, messageSize);
@@ -190,6 +192,7 @@ void openxc::pipeline::publish(openxc_VehicleMessage* message,
             break;
     }
     if(matched) {
+        debug("debug for Ja'mez pipeline line 195 %d", message->type);
         sendMessage(pipeline, payload, length, messageClass);
 
     } else {

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -80,8 +80,6 @@ void sendToUsb(Pipeline* pipeline, uint8_t* message, int messageSize,
         }
 
         conditionalFlush(pipeline, sendQueue, message, messageSize);
-        debug("sendtoUSB debug pipeline line 83");
-        debug((const char*)message);
         sendToEndpoint(pipeline->usb->descriptor.type, sendQueue,
                 &pipeline->usb->endpoints[OUT_ENDPOINT_INDEX].queue,
                 message, messageSize);
@@ -192,7 +190,6 @@ void openxc::pipeline::publish(openxc_VehicleMessage* message,
             break;
     }
     if(matched) {
-        debug("debug for Ja'mez pipeline line 195 %d", message->type);
         sendMessage(pipeline, payload, length, messageClass);
 
     } else {

--- a/src/platform/lpc17xx/canread.cpp
+++ b/src/platform/lpc17xx/canread.cpp
@@ -2,6 +2,7 @@
 #include "canutil_lpc17xx.h"
 #include "signals.h"
 #include "util/log.h"
+#include "diagnostics.h"
 
 using openxc::util::log::debug;
 using openxc::signals::getCanBusCount;
@@ -25,6 +26,10 @@ CanMessage receiveCanMessage(CanBus* bus) {
     return result;
 }
 
+void filterForVinLocal(CanMessage* message) {
+    openxc::diagnostics::filterForVIN(message);
+}
+
 extern "C" {
 
 void CAN_IRQHandler() {
@@ -32,6 +37,7 @@ void CAN_IRQHandler() {
         CanBus* bus = &getCanBuses()[i];
         if((CAN_IntGetStatus(CAN_CONTROLLER(bus)) & 0x01) == 1) {
             CanMessage message = receiveCanMessage(bus);
+            filterForVinLocal(&message);
             if(shouldAcceptMessage(bus, message.id) &&
                     !QUEUE_PUSH(CanMessage, &bus->receiveQueue, message)) {
                 // An exception to the "don't leave commented out code" rule,

--- a/src/platform/pic32/canread.cpp
+++ b/src/platform/pic32/canread.cpp
@@ -3,6 +3,7 @@
 #include "signals.h"
 #include "util/log.h"
 #include "power.h"
+#include "diagnostics.h"
 
 namespace power = openxc::power;
 
@@ -47,6 +48,7 @@ void openxc::can::pic32::handleCanInterrupt(CanBus* bus) {
                 CAN::RX_CHANNEL_NOT_EMPTY, false);
 
         CanMessage message = receiveCanMessage(bus);
+        openxc::diagnostics::filterForVIN(&message);
         if(!QUEUE_PUSH(CanMessage, &bus->receiveQueue, message)) {
             // An exception to the "don't leave commented out code" rule,
             // this log statement is useful for debugging performance issues


### PR DESCRIPTION
Add logic for the get_vin command to get VIN from a diagnostic request if it failed to get the VIN from CAN traffic.  New logic in diagnostic.cpp to recognize if a diagnostic request is coming from the get_vin command.  

**Note: get_vin command diagnostic request is message_id:7e0, mode:9, pid:2.**  This may change in the future as we still have to look into why message_id:7df is not responding with the full VIN.